### PR TITLE
#5 Allow set transaction description

### DIFF
--- a/Client/Client.php
+++ b/Client/Client.php
@@ -46,11 +46,17 @@ class Client
         /** @var ExtendedDataInterface $data */
         $data = $transaction->getExtendedData();
         $data->set('inv_id', $inv_id);
+        
+        $description = 'test desc';
+        if($data->has('description')) {
+            $description = $data->get('description');
+        }
+        
         $parameters = [
             'MrchLogin' => $this->login,
             'OutSum' => $transaction->getRequestedAmount(),
             'InvId' => $inv_id,
-            'Desc' => 'test desc',
+            'Desc' => $description,
             'IncCurrLabel' => '',
             'SignatureValue' => $this->auth->sign($this->login, $transaction->getRequestedAmount(), $inv_id)
         ];


### PR DESCRIPTION
Now it's possible to add transaction description like follow:
<pre>
$form = $this->getFormFactory()->create('jms_choose_payment_method', null, array(
            'amount'   => $price,
            'currency' => $currency,
            'default_method' => 'robokassa', // Optional
            'predefined_data' => array(
                'robokassa' => array(
                    'return_url' => 'whatever',
                    'cancel_url' => 'whatever',
                    'description' => 'order description'
                ),
            ),
        ));
</pre>