### PR TITLE
Tiny fix for one of the Yaml deprecations

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,21 +5,21 @@ parameters:
     karser.robokassa.client.auth.class: Karser\RobokassaBundle\Client\Auth
 services:
     karser.form.type.robokassa:
-        class: %karser.form.type.robokassa.class%
+        class: "%karser.form.type.robokassa.class%"
         tags:
             - { name: "payment.method_form_type" }
             - { name: "form.type", alias: "robokassa" }
 
     karser.plugin.robokassa:
-        class: %karser.plugin.robokassa.class%
-        arguments: [ "@karser.robokassa.client", %karser_robokassa.debug% ]
+        class: "%karser.plugin.robokassa.class%"
+        arguments: [ "@karser.robokassa.client", "%karser_robokassa.debug%" ]
         tags:
             - { name: "payment.plugin" }
 
     karser.robokassa.client:
-        class: %karser.robokassa.client.class%
-        arguments: [ "@karser.robokassa.client.auth", %karser_robokassa.login%, %karser_robokassa.test% ]
+        class: "%karser.robokassa.client.class%"
+        arguments: [ "@karser.robokassa.client.auth", "%karser_robokassa.login%, %karser_robokassa.test%" ]
 
     karser.robokassa.client.auth:
-        class: %karser.robokassa.client.auth.class%
-        arguments: [ %karser_robokassa.password1%, %karser_robokassa.password2% ]
+        class: "%karser.robokassa.client.auth.class%"
+        arguments: [ "%karser_robokassa.password1%", "%karser_robokassa.password2%" ]


### PR DESCRIPTION
Lets get more clear logs for symfony versions 3.1 or above.

https://github.com/symfony/symfony/blob/3.4/UPGRADE-3.1.md#yaml

Usage of % at the beginning of an unquoted string has been deprecated and will lead to a ParseException in Symfony 4.0.

![screenshot_20180523_151939](https://user-images.githubusercontent.com/2945846/40423986-d4d1ff38-5e9c-11e8-884d-5a40a4a362ac.png)
